### PR TITLE
 Bewertet Version

### DIFF
--- a/Uebung_03.ipynb
+++ b/Uebung_03.ipynb
@@ -218,7 +218,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "Der Wahrheitswert der Aussage ist falsch da nach dem Berechnungsprinzip, Gleitkommazahlen durch Bruchteile berechnet und dargestellt werden. Daher lassen sich die Nachkommastellen nicht hundertprozent richtig darstellen."
+    "Der Wahrheitswert der Aussage ist falsch da nach dem Berechnungsprinzip, Gleitkommazahlen durch Bruchteile berechnet und dargestellt werden. Daher lassen sich die Nachkommastellen nicht hundertprozent richtig darstellen. #"
    ]
   }
  ],


### PR DESCRIPTION
Afg.3 "Gleitkommazahlen durch Bruchteile berechnet und dargestellt werden." durch Binär dargestellt und berechnet. (-5)